### PR TITLE
chore: add env example file

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,5 @@
+SUPABASE_ACCESS_TOKEN=sbp_your_token_here
+SUPABASE_PROJECT_REF=rubogzqkoulwvrojavtl
+SUPABASE_ANON_KEY=your_anon_key
+SUPABASE_SERVICE_ROLE_KEY=your_service_role_key
+SUPABASE_DB_HOST=your_db_host

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ out/
 dist/
 .env
 .env.*
+!.env.example
 # supabase
 supabase/.temp/
 .supabase/


### PR DESCRIPTION
## Summary
- add `.env.example` with placeholders for Supabase keys
- allow committing the example env file via `.gitignore`

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a39ff09ec0832687773d9022469024