### PR TITLE
chore: remove obsolete env example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,6 @@ out/
 dist/
 .env
 .env.*
-!.env.example
 # supabase
 supabase/.temp/
 .supabase/


### PR DESCRIPTION
## Summary
- remove unneeded .env.example rule

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68a490e217d88326a106a2f40c6d5988